### PR TITLE
Fix numerical instability on `CheckRotationMatrix()` for small elements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 cmake_minimum_required(VERSION 3.23)
-set(BSMPT_VERSION 3.1.14)
+set(BSMPT_VERSION 3.1.15)
 project(
   BSMPT
   VERSION ${BSMPT_VERSION}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas M�
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-Program: BSMPT version 3.1.14
+Program: BSMPT version 3.1.15
 
 Released by: Philipp Basler, Lisa Biermann, Margarete Mühlleitner, Jonas Müller, Rui Santos and João Viana
 

--- a/src/models/ClassPotentialOrigin.cpp
+++ b/src/models/ClassPotentialOrigin.cpp
@@ -971,9 +971,12 @@ bool Class_Potential_Origin::CheckRotationMatrix()
     }
   }
 
-  double precision = 1e-10;
+  const double det_precision = 1e-10; // det precision
+  const double el_precision =
+      1e-8; // element precision. different precision to prevent numerical
+            // instabilities for small elements
 
-  if (!almost_the_same(std::abs(mat.determinant()), 1., precision))
+  if (!almost_the_same(std::abs(mat.determinant()), 1., det_precision))
   {
     return false;
   }
@@ -985,7 +988,7 @@ bool Class_Potential_Origin::CheckRotationMatrix()
   {
     for (std::size_t j = 0; j < NHiggs; j++)
     {
-      if (!almost_the_same(inv(i, j), transp(i, j), precision))
+      if (!almost_the_same(inv(i, j), transp(i, j), el_precision))
       {
         return false;
       }

--- a/tests/unittests/Test-c2hdm.cpp
+++ b/tests/unittests/Test-c2hdm.cpp
@@ -44,6 +44,34 @@ TEST_CASE("Run CheckImplementation in c2hdm", "[c2hdm]")
   REQUIRE(output.find("fail") == std::string::npos);
 }
 
+TEST_CASE("Check 'CheckRotationMatrix()' c2hdm", "[c2hdm]")
+{
+  using namespace BSMPT;
+  const std::vector<double> problematic_point_C2HDM{
+      /* lambda_1 = */ 4.2449116270277205,
+      /* lambda_2 = */ 1.6012296919722049,
+      /* lambda_3 = */ 5.5019521141735925,
+      /* lambda_4 = */ -5.420480049856172,
+      /* Re(lambda_5) = */ -2.174405759032836,
+      /* Im(lambda_5) = */ 0.0002392204965281,
+      /* Re(m_{12}^2) = */ 92344.388000000006,
+      /* tan(beta) = */ 1.4760931000000002,
+      /* Yukawa Type = */ 1};
+
+  const auto SMConstants = GetSMConstants();
+  std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
+  modelPointer->initModel(problematic_point_C2HDM);
+  modelPointer->write();
+  std::stringstream ss;
+  Logger::SetOStream(ss);
+  REQUIRE_NOTHROW(ModelTests::CheckImplementation(
+      *modelPointer, Minimizer::WhichMinimizerDefault));
+  Logger::SetOStream(std::cout);
+  std::string output = ss.str();
+  REQUIRE(output.find("fail") == std::string::npos);
+}
+
 TEST_CASE("Checking NLOVEV for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;


### PR DESCRIPTION
## Description

For some points there were numerical instabilities on `CheckRotationMatrix()` for small elements. So I lowered the acceptance precision for elements but kept the precision for the determinant.

<!-- Provide a brief description of the change and the purpose of the PR. -->

## Type of Change

<!-- Please select only a single option with an "x" or "X". -->

 - [ ] Break (major)
 - [ ] Feature (minor)
 - [x] Bug fix (patch)
 - [ ] No source changes (no version change)
