### PR TITLE
Fix action near Tc and improve logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 cmake_minimum_required(VERSION 3.23)
-set(BSMPT_VERSION 3.3.0)
+set(BSMPT_VERSION 3.3.1)
 project(
   BSMPT
   VERSION ${BSMPT_VERSION}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas M�
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-Program: BSMPT version 3.3.0
+Program: BSMPT version 3.3.1
 
 Released by: Philipp Basler, Lisa Biermann, Margarete Mühlleitner, Jonas Müller, Rui Santos and João Viana
 

--- a/include/BSMPT/transition_tracer/transition_tracer.h
+++ b/include/BSMPT/transition_tracer/transition_tracer.h
@@ -130,15 +130,15 @@ struct gw_data
   std::optional<double> cs_t;
 
   std::optional<double> fb_col;
-  std::optional<double> omegab_col;
+  std::optional<double> h2omegab_col;
 
   std::optional<double> f1_sw;
   std::optional<double> f2_sw;
-  std::optional<double> omega_2_sw;
+  std::optional<double> h2omega_2_sw;
 
   std::optional<double> f1_turb;
   std::optional<double> f2_turb;
-  std::optional<double> omega_2_turb;
+  std::optional<double> h2omega_2_turb;
 
   std::optional<double> SNR_col;
   std::optional<double> SNR_sw;

--- a/src/bounce_solution/bounce_solution.cpp
+++ b/src/bounce_solution/bounce_solution.cpp
@@ -149,7 +149,9 @@ void BounceSolution::GWInitialScan()
 
   for (double T = Tc - dT; T >= phase_pair.T_low + dT; T -= dT)
   {
-    Logger::Write(LoggingLevel::BounceDetailed, "T = " + std::to_string(T));
+    Logger::Write(LoggingLevel::BounceDetailed,
+                  "[InitialScan] Calculating action at T = " +
+                      std::to_string(T));
 
     // Check if transition is energetically viable
     if (phase_pair.true_phase.Get(T).potential >=

--- a/src/bounce_solution/bounce_solution.cpp
+++ b/src/bounce_solution/bounce_solution.cpp
@@ -206,7 +206,8 @@ void BounceSolution::CalculateActionAt(double T, bool smart)
 {
   // Action outside allowed range
   if (T < Tm or T > Tc) return;
-  Logger::Write(LoggingLevel::BounceDetailed, " T = " + std::to_string(T));
+  Logger::Write(LoggingLevel::BounceDetailed,
+                "Calculating action at T = " + std::to_string(T));
   // Find the closest solution to our goal temperature
   if (SolutionList.size() > 0)
   {
@@ -217,7 +218,7 @@ void BounceSolution::CalculateActionAt(double T, bool smart)
                          { return std::abs(T - a.T) < std::abs(T - b.T); });
     BounceActionInt Nearest_bc = *it;
 
-    if (abs(Nearest_bc.T - T) < 0.001) return;
+    if (abs(Nearest_bc.T - T) < 1e-4) return;
 
     // Check if transition is energetically viable
     if (phase_pair.true_phase.Get(T).potential >=

--- a/src/gravitational_waves/gw.cpp
+++ b/src/gravitational_waves/gw.cpp
@@ -176,13 +176,13 @@ void GravitationalWave::CalcPeakCollision()
                         1. / 2. * pow(-n1 / n2, -n2 / (n1 - n2)),
                     (n1 - n2) / a1);
 
-  Logger::Write(LoggingLevel::GWDetailed,
-                "\n--------------- Collision ---------------\n");
-  Logger::Write(LoggingLevel::GWDetailed,
-                "f_b = " + std::to_string(data.CollisionParameter.f_b.value()));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "Omega_b = " +
-                    std::to_string(data.CollisionParameter.Omega_b.value()));
+  std::stringstream ss;
+
+  ss << "\n--------------- Collision ---------------\n\n";
+  ss << "f_b = " << data.CollisionParameter.f_b.value() << "\n";
+  ss << "h^2 Omega_b  = " << h * h * data.CollisionParameter.Omega_b.value();
+
+  Logger::Write(LoggingLevel::GWDetailed, ss.str());
 }
 
 double GravitationalWave::CalculateXiShell()
@@ -230,15 +230,15 @@ void GravitationalWave::CalcPeakSoundWave()
   data.SoundWaveParameter.f_2 = f_2;
   data.SoundWaveParameter.Omega_2 =
       Omega_int * (sqrt(2) + (2 * f_2 / f_1) / (1 + pow(f_2 / f_1, 2))) / M_PI;
-  Logger::Write(LoggingLevel::GWDetailed,
-                "\n--------------- Sound Wave ---------------\n");
-  Logger::Write(LoggingLevel::GWDetailed,
-                "f_1 = " + std::to_string(data.SoundWaveParameter.f_1.value()));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "f_2 = " + std::to_string(data.SoundWaveParameter.f_2.value()));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "Omega_2 = " +
-                    std::to_string(data.SoundWaveParameter.Omega_2.value()));
+
+  std::stringstream ss;
+
+  ss << "\n--------------- Sound Wave ---------------\n\n";
+  ss << "f_1 = " << data.SoundWaveParameter.f_1.value() << "\n";
+  ss << "f_2 = " << data.SoundWaveParameter.f_2.value() << "\n";
+  ss << "h^2 Omega_2 = " << h * h * data.SoundWaveParameter.Omega_2.value();
+
+  Logger::Write(LoggingLevel::GWDetailed, ss.str());
 }
 
 void GravitationalWave::CalcPeakTurbulence()
@@ -266,17 +266,14 @@ void GravitationalWave::CalcPeakTurbulence()
   data.TurbulanceParameter.Omega_2 =
       data.FGW0 * A_MHD * pow(Omega_s, 2) * pow(data.HR, 2);
 
-  Logger::Write(LoggingLevel::GWDetailed,
-                "\n--------------- Turbulence ---------------\n");
-  Logger::Write(LoggingLevel::GWDetailed,
-                "f_1 = " +
-                    std::to_string(data.TurbulanceParameter.f_1.value()));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "f_2 = " +
-                    std::to_string(data.TurbulanceParameter.f_2.value()));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "Omega_2 = " +
-                    std::to_string(data.TurbulanceParameter.Omega_2.value()));
+  std::stringstream ss;
+
+  ss << "\n--------------- Turbulence ---------------\n\n";
+  ss << "f_1 = " << data.TurbulanceParameter.f_1.value() << "\n";
+  ss << "f_2 = " << data.TurbulanceParameter.f_2.value() << "\n";
+  ss << "h^2 Omega_2 = " << h * h * data.TurbulanceParameter.Omega_2.value();
+
+  Logger::Write(LoggingLevel::GWDetailed, ss.str());
 }
 
 double GravitationalWave::BPL(const double &f, const BPLParameters &par) const

--- a/src/gravitational_waves/gw.cpp
+++ b/src/gravitational_waves/gw.cpp
@@ -26,27 +26,21 @@ GravitationalWave::GravitationalWave(
   data.PTStrength     = BACalc.GetPTStrength();
   data.betaH          = BACalc.GetInvTimeScale();
   data.vw             = BACalc.GetWallVelocity();
-  Logger::Write(LoggingLevel::GWDetailed,
-                "\n--------------- Transition parameters ---------------\n");
-  Logger::Write(LoggingLevel::GWDetailed,
-                "T* = " + std::to_string(data.transitionTemp));
+  std::stringstream ss;
+  ss << "\n--------------- Transition parameters ---------------\n\n";
+  ss << "T* = " << data.transitionTemp << "\n";
+  ss << "Th = " << data.reheatingTemp << "\n";
+  ss << "alpha = " << data.PTStrength << "\n";
+  ss << "beta/H = " << data.betaH << "\n";
+  ss << "vw = " << data.vw << "\n\n";
 
-  Logger::Write(LoggingLevel::GWDetailed,
-                "Th = " + std::to_string(data.reheatingTemp));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "alpha = " + std::to_string(data.PTStrength));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "beta/H = " + std::to_string(data.betaH));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "vw = " + std::to_string(data.vw) + "\n");
   // Sound speeds
   data.Csound_false = BACalc.GetSoundSpeedFalse();
   data.Csound_true  = BACalc.GetSoundSpeedTrue();
 
-  Logger::Write(LoggingLevel::GWDetailed,
-                "Csound_false = " + std::to_string(data.Csound_false));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "Csound_true = " + std::to_string(data.Csound_true));
+  ss << "Csound_false = " << data.Csound_false << "\n";
+  ss << "Csound_true = " << data.Csound_true << "\n";
+
   // General purpose GW parameters
   data.HR    = BACalc.GetRstar() * BACalc.HubbleRate(data.transitionTemp);
   data.gstar = BACalc.GetGstar(data.transitionTemp);
@@ -72,22 +66,16 @@ GravitationalWave::GravitationalWave(
                                         alpha_eff,
                                         BACalc.vwall,
                                         vprofile);
-  Logger::Write(LoggingLevel::GWDetailed, "HR = " + std::to_string(data.HR));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "gstar = " + std::to_string(data.gstar));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "FGW0 = " + std::to_string(data.FGW0));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "Hstar0 = " + std::to_string(data.Hstar0));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "kappa_col = " + std::to_string(data.kappa_col));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "Epsilon_Turb = " + std::to_string(data.Epsilon_Turb));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "alpha_eff = " + std::to_string(alpha_eff));
-  Logger::Write(LoggingLevel::GWDetailed, "vCJ = " + std::to_string(data.vCJ));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "kappa_sw = " + std::to_string(data.kappa_sw));
+  ss << "HR = " << data.HR << "\n";
+  ss << "gstar = " << data.gstar << "\n";
+  ss << "FGW0 = " << data.FGW0 << "\n";
+  ss << "Hstar0 = " << data.Hstar0 << "\n";
+
+  ss << "Epsilon_Turb = " << data.Epsilon_Turb << "\n";
+  ss << "alpha_eff = " << alpha_eff << "\n";
+  ss << "vCJ = " << data.vCJ << "\n";
+  ss << "kappa_sw = " << data.kappa_sw << "\n";
+  ss << "kappa_col = " << data.kappa_col << "\n";
   // XiShock = fastest fluid shell
   if (data.kappa_sw > 0)
   {
@@ -99,10 +87,11 @@ GravitationalWave::GravitationalWave(
   }
 
   data.K_sw = GetK_sw(data.PTStrength, data.kappa_sw);
-  Logger::Write(LoggingLevel::GWDetailed,
-                "XiShock= " + std::to_string(data.XiShock));
-  Logger::Write(LoggingLevel::GWDetailed,
-                "K_sw = " + std::to_string(data.K_sw));
+  ss << "XiShock= " << data.XiShock << "\n";
+  ss << "K_sw = " << data.K_sw;
+
+  Logger::Write(LoggingLevel::GWDetailed, ss.str());
+
   if (data.betaH < 1)
   {
     data.status = StatusGW::Failure;

--- a/src/prog/CalcGW.cpp
+++ b/src/prog/CalcGW.cpp
@@ -204,14 +204,16 @@ try
               << sep << output.vec_gw_data.at(i).cs_f.value_or(EmptyValue)
               << sep << output.vec_gw_data.at(i).cs_t.value_or(EmptyValue)
               << sep << output.vec_gw_data.at(i).fb_col.value_or(EmptyValue)
-              << sep << output.vec_gw_data.at(i).omegab_col.value_or(EmptyValue)
+              << sep
+              << output.vec_gw_data.at(i).h2omegab_col.value_or(EmptyValue)
               << sep << output.vec_gw_data.at(i).f1_sw.value_or(EmptyValue)
               << sep << output.vec_gw_data.at(i).f2_sw.value_or(EmptyValue)
-              << sep << output.vec_gw_data.at(i).omega_2_sw.value_or(EmptyValue)
+              << sep
+              << output.vec_gw_data.at(i).h2omega_2_sw.value_or(EmptyValue)
               << sep << output.vec_gw_data.at(i).f1_turb.value_or(EmptyValue)
               << sep << output.vec_gw_data.at(i).f2_turb.value_or(EmptyValue)
               << sep
-              << output.vec_gw_data.at(i).omega_2_turb.value_or(EmptyValue)
+              << output.vec_gw_data.at(i).h2omega_2_turb.value_or(EmptyValue)
               << sep << output.vec_gw_data.at(i).SNR_col.value_or(EmptyValue)
               << sep << output.vec_gw_data.at(i).SNR_sw.value_or(EmptyValue)
               << sep << output.vec_gw_data.at(i).SNR_turb.value_or(EmptyValue)

--- a/src/transition_tracer/transition_tracer.cpp
+++ b/src/transition_tracer/transition_tracer.cpp
@@ -313,22 +313,23 @@ TransitionTracer::TransitionTracer(user_input &input)
 
                 if (new_gw_data.status_gw != StatusGW::Failure)
                 {
+                  const double h = gw.h;
                   gw.CalcPeakCollision();
                   new_gw_data.fb_col = gw.data.CollisionParameter.f_b.value();
-                  new_gw_data.omegab_col =
-                      gw.data.CollisionParameter.Omega_b.value();
+                  new_gw_data.h2omegab_col =
+                      h * h * gw.data.CollisionParameter.Omega_b.value();
 
                   gw.CalcPeakSoundWave();
                   new_gw_data.f1_sw = gw.data.SoundWaveParameter.f_1.value();
                   new_gw_data.f2_sw = gw.data.SoundWaveParameter.f_2.value();
-                  new_gw_data.omega_2_sw =
-                      gw.data.SoundWaveParameter.Omega_2.value();
+                  new_gw_data.h2omega_2_sw =
+                      h * h * gw.data.SoundWaveParameter.Omega_2.value();
 
                   gw.CalcPeakTurbulence();
                   new_gw_data.f1_turb = gw.data.TurbulanceParameter.f_1.value();
                   new_gw_data.f2_turb = gw.data.TurbulanceParameter.f_2.value();
-                  new_gw_data.omega_2_turb =
-                      gw.data.TurbulanceParameter.Omega_2.value();
+                  new_gw_data.h2omega_2_turb =
+                      h * h * gw.data.TurbulanceParameter.Omega_2.value();
 
                   std::stringstream ss;
 

--- a/src/transition_tracer/transition_tracer.cpp
+++ b/src/transition_tracer/transition_tracer.cpp
@@ -330,11 +330,18 @@ TransitionTracer::TransitionTracer(user_input &input)
                   new_gw_data.omega_2_turb =
                       gw.data.TurbulanceParameter.Omega_2.value();
 
+                  std::stringstream ss;
+
+                  ss << "\n--------------- SNR ---------------\n\n";
+
                   // SNR of Collision
                   gw.data.collisionON = true;
                   gw.data.swON        = false;
                   gw.data.turbON      = false;
                   new_gw_data.SNR_col = gw.GetSNR(1e-6, 10);
+
+                  ss << "SNR(collision) = " << new_gw_data.SNR_col.value_or(NAN)
+                     << "\n";
 
                   // SNR of Sound Waves
                   gw.data.collisionON = false;
@@ -342,17 +349,29 @@ TransitionTracer::TransitionTracer(user_input &input)
                   gw.data.turbON      = false;
                   new_gw_data.SNR_sw  = gw.GetSNR(1e-6, 10);
 
+                  ss << "SNR(sound waves) = "
+                     << new_gw_data.SNR_sw.value_or(NAN) << "\n";
+
                   // SNR of Turbulence
                   gw.data.collisionON  = false;
                   gw.data.swON         = false;
                   gw.data.turbON       = true;
                   new_gw_data.SNR_turb = gw.GetSNR(1e-6, 10);
 
+                  ss << "SNR(turbulence) = "
+                     << new_gw_data.SNR_turb.value_or(NAN) << "\n";
+
                   // SNR of all contributions
                   gw.data.collisionON = true;
                   gw.data.swON        = true;
                   gw.data.turbON      = true;
                   new_gw_data.SNR     = gw.GetSNR(1e-6, 10);
+
+                  ss << "\nSNR(collison + sound waves + turbulence) "
+                        "= "
+                     << new_gw_data.SNR.value_or(NAN) << "\n";
+
+                  Logger::Write(LoggingLevel::GWDetailed, ss.str());
 
                   new_gw_data.kappa_col    = gw.data.kappa_col;
                   new_gw_data.kappa_sw     = gw.data.kappa_sw;

--- a/tests/unittests/Test-gw.cpp
+++ b/tests/unittests/Test-gw.cpp
@@ -959,21 +959,22 @@ TEST_CASE("Checking phase tracking and GW for BP3", "[gw]")
   REQUIRE(0.0170023112894 ==
           Approx(output.vec_gw_data.at(0).fb_col.value()).epsilon(1e-2));
   REQUIRE(0. ==
-          Approx(output.vec_gw_data.at(0).omegab_col.value()).epsilon(1e-2));
+          Approx(output.vec_gw_data.at(0).h2omegab_col.value()).epsilon(1e-2));
 
   REQUIRE(0.00744305239818 ==
           Approx(output.vec_gw_data.at(0).f1_sw.value()).epsilon(1e-2));
   REQUIRE(0.0470969569436 ==
           Approx(output.vec_gw_data.at(0).f2_sw.value()).epsilon(1e-2));
-  REQUIRE(9.05885430918e-20 ==
-          Approx(output.vec_gw_data.at(0).omega_2_sw.value()).epsilon(1e-2));
+  REQUIRE(4.1152201001570546e-20 ==
+          Approx(output.vec_gw_data.at(0).h2omega_2_sw.value()).epsilon(1e-2));
 
   REQUIRE(2.69271850203e-05 ==
           Approx(output.vec_gw_data.at(0).f1_turb.value()).epsilon(1e-2));
   REQUIRE(0.08187357638 ==
           Approx(output.vec_gw_data.at(0).f2_turb.value()).epsilon(1e-2));
-  REQUIRE(3.51603674416e-25 ==
-          Approx(output.vec_gw_data.at(0).omega_2_turb.value()).epsilon(1e-2));
+  REQUIRE(
+      1.5972511079900284e-25 ==
+      Approx(output.vec_gw_data.at(0).h2omega_2_turb.value()).epsilon(1e-2));
 
   REQUIRE(0 == Approx(output.vec_gw_data.at(0).SNR_col.value()).epsilon(5e-2));
   REQUIRE(9.15003140408e-08 ==
@@ -1057,21 +1058,22 @@ TEST_CASE("Checking phase tracking and GW for BP3 (low sample) and not "
   REQUIRE(0.0170282844073 ==
           Approx(output.vec_gw_data.at(0).fb_col.value()).epsilon(1e-2));
   REQUIRE(0. ==
-          Approx(output.vec_gw_data.at(0).omegab_col.value()).epsilon(1e-2));
+          Approx(output.vec_gw_data.at(0).h2omegab_col.value()).epsilon(1e-2));
 
   REQUIRE(0.00745408785087 ==
           Approx(output.vec_gw_data.at(0).f1_sw.value()).epsilon(1e-2));
   REQUIRE(0.0471667878942 ==
           Approx(output.vec_gw_data.at(0).f2_sw.value()).epsilon(1e-2));
-  REQUIRE(9.03362471629e-20 ==
-          Approx(output.vec_gw_data.at(0).omega_2_sw.value()).epsilon(1e-2));
+  REQUIRE(4.1037589016173564e-20 ==
+          Approx(output.vec_gw_data.at(0).h2omega_2_sw.value()).epsilon(1e-2));
 
   REQUIRE(2.69667207673e-05 ==
           Approx(output.vec_gw_data.at(0).f1_turb.value()).epsilon(1e-2));
   REQUIRE(0.0819949663596 ==
           Approx(output.vec_gw_data.at(0).f2_turb.value()).epsilon(1e-2));
-  REQUIRE(3.50544513664e-25 ==
-          Approx(output.vec_gw_data.at(0).omega_2_turb.value()).epsilon(1e-2));
+  REQUIRE(
+      1.5924395948922728e-25 ==
+      Approx(output.vec_gw_data.at(0).h2omega_2_turb.value()).epsilon(1e-2));
 
   REQUIRE(0 == Approx(output.vec_gw_data.at(0).SNR_col.value()).epsilon(5e-2));
   REQUIRE(9.09581393167e-08 ==
@@ -1146,13 +1148,13 @@ TEST_CASE(
   REQUIRE(not output.vec_gw_data.at(0).kappa_col.has_value());
   REQUIRE(not output.vec_gw_data.at(0).kappa_sw.has_value());
   REQUIRE(not output.vec_gw_data.at(0).fb_col.has_value());
-  REQUIRE(not output.vec_gw_data.at(0).omegab_col.has_value());
+  REQUIRE(not output.vec_gw_data.at(0).h2omegab_col.has_value());
   REQUIRE(not output.vec_gw_data.at(0).f1_sw.has_value());
   REQUIRE(not output.vec_gw_data.at(0).f2_sw.has_value());
-  REQUIRE(not output.vec_gw_data.at(0).omega_2_sw.has_value());
+  REQUIRE(not output.vec_gw_data.at(0).h2omega_2_sw.has_value());
   REQUIRE(not output.vec_gw_data.at(0).f1_turb.has_value());
   REQUIRE(not output.vec_gw_data.at(0).f2_turb.has_value());
-  REQUIRE(not output.vec_gw_data.at(0).omega_2_turb.has_value());
+  REQUIRE(not output.vec_gw_data.at(0).h2omega_2_turb.has_value());
   REQUIRE(not output.vec_gw_data.at(0).SNR_col.has_value());
   REQUIRE(not output.vec_gw_data.at(0).SNR_sw.has_value());
   REQUIRE(not output.vec_gw_data.at(0).SNR_turb.has_value());


### PR DESCRIPTION
## Description

- Fixed the missmatch between the output file and its value, there was a $h^2$ factor missing. We were printing $\Omega_{sw/turb/col}$ instead of $h^2\Omega_{sw/turb/col}$
- Use `std::stringstream` instead of `std::to_string()` to print the output. Issue: if the value was close to zero we would only print `0`
- Decreased the threshold to **not** calculate the action at some temperature if there is already another action calculated at a close temperature.

<!-- Provide a brief description of the change and the purpose of the PR. -->

## Type of Change

<!-- Please select only a single option with an "x" or "X". -->

 - [ ] Break (major)
 - [ ] Feature (minor)
 - [x] Bug fix (patch)
 - [ ] No source changes (no version change)
