### PR TITLE
Missing CT on the R2HDM, Chapman-Jouguet, GSL integration error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 cmake_minimum_required(VERSION 3.23)
-set(BSMPT_VERSION 3.3.1)
+set(BSMPT_VERSION 3.3.2)
 project(
   BSMPT
   VERSION ${BSMPT_VERSION}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas M�
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-Program: BSMPT version 3.3.1
+Program: BSMPT version 3.3.2
 
 Released by: Philipp Basler, Lisa Biermann, Margarete Mühlleitner, Jonas Müller, Rui Santos and João Viana
 

--- a/include/BSMPT/bounce_solution/bounce_solution.h
+++ b/include/BSMPT/bounce_solution/bounce_solution.h
@@ -666,7 +666,7 @@ public:
 
   /**
    * @brief Derive the Chapman-Jouget velocity from PT strength and false phase
-   * sound velocity using Eq. (55) of 2004.06995
+   * sound velocity using Eq. (21) of https://arxiv.org/pdf/1004.4187
    */
   void CalcChapmanJougetVelocity();
 

--- a/src/bounce_solution/bounce_solution.cpp
+++ b/src/bounce_solution/bounce_solution.cpp
@@ -1117,8 +1117,9 @@ void BounceSolution::CalculatePTStrength()
 void BounceSolution::CalcChapmanJougetVelocity()
 {
   const double vminusterm = Csound_false / 2 + 1 / (6 * Csound_false);
-  vCJ                     = 1 / (1 + std::max(0., alpha)) * (vminusterm) +
-        sqrt(pow(vminusterm, 2) + pow(alpha, 2) + 2. / 3. * alpha - 1. / 3.);
+  vCJ                     = 1 / (1 + std::max(0., alpha)) *
+        ((vminusterm) +
+         sqrt(pow(vminusterm, 2) + pow(alpha, 2) + 2. / 3. * alpha - 1. / 3.));
 }
 
 void BounceSolution::CalculateWallVelocity(const Minimum &false_min,

--- a/src/bounce_solution/bounce_solution.cpp
+++ b/src/bounce_solution/bounce_solution.cpp
@@ -1116,10 +1116,9 @@ void BounceSolution::CalculatePTStrength()
 
 void BounceSolution::CalcChapmanJougetVelocity()
 {
-  vCJ = (1 + std::sqrt(3 * alpha *
-                       (1 - Csound_false * Csound_false +
-                        3 * Csound_false * Csound_false * alpha))) /
-        (1. / Csound_false + 3 * Csound_false * alpha);
+  const double vminusterm = Csound_false / 2 + 1 / (6 * Csound_false);
+  vCJ = 1 / (1 + std::max(0., alpha)) * (vminusterm) +
+        sqrt(pow(vminusterm, 2) + pow(alpha, 2) + 2. / 3. * alpha - 1. / 3.);
 }
 
 void BounceSolution::CalculateWallVelocity(const Minimum &false_min,

--- a/src/bounce_solution/bounce_solution.cpp
+++ b/src/bounce_solution/bounce_solution.cpp
@@ -1117,7 +1117,7 @@ void BounceSolution::CalculatePTStrength()
 void BounceSolution::CalcChapmanJougetVelocity()
 {
   const double vminusterm = Csound_false / 2 + 1 / (6 * Csound_false);
-  vCJ = 1 / (1 + std::max(0., alpha)) * (vminusterm) +
+  vCJ                     = 1 / (1 + std::max(0., alpha)) * (vminusterm) +
         sqrt(pow(vminusterm, 2) + pow(alpha, 2) + 2. / 3. * alpha - 1. / 3.);
 }
 
@@ -1268,11 +1268,33 @@ void BounceSolution::CalculateRstar()
   };
   F.params = this; // Pass `this` pointer as parameters
 
-  double result, error;
-  gsl_integration_qags(
-      &F, Tstar, Tc, RelErr, AbsErr, 1000, workspace, &result, &error);
+  double result_qags, error_qags;
+  gsl_integration_qags(&F,
+                       Tstar,
+                       Tc,
+                       AbsErr,
+                       RelErr,
+                       1000,
+                       workspace,
+                       &result_qags,
+                       &error_qags);
+
+  double result_qag, error_qag;
+  int key = 6; // GSL_INTEG_GAUSS61; default for qags is GSL_INTEG_GAUSS21
+  gsl_integration_qag(&F,
+                      Tstar,
+                      Tc,
+                      AbsErr,
+                      RelErr,
+                      1000,
+                      key,
+                      workspace,
+                      &result_qag,
+                      &error_qag);
 
   gsl_integration_workspace_free(workspace);
+
+  const double result = (error_qags < error_qag ? result_qags : result_qag);
 
   this->Rstar = pow(pow(Tstar, 3) * result, -1 / 3.);
 }

--- a/src/bounce_solution/bounce_solution.cpp
+++ b/src/bounce_solution/bounce_solution.cpp
@@ -10,6 +10,7 @@
 #include <BSMPT/bounce_solution/bounce_solution.h>
 #include <BSMPT/utility/NumericalDerivatives.h>
 #include <BSMPT/utility/asciiplotter/asciiplotter.h>
+#include <gsl/gsl_errno.h>
 namespace BSMPT
 {
 
@@ -1269,6 +1270,8 @@ void BounceSolution::CalculateRstar()
   };
   F.params = this; // Pass `this` pointer as parameters
 
+  gsl_error_handler_t *old_handler = gsl_set_error_handler_off();
+
   double result_qags, error_qags;
   gsl_integration_qags(&F,
                        Tstar,
@@ -1298,5 +1301,7 @@ void BounceSolution::CalculateRstar()
   const double result = (error_qags < error_qag ? result_qags : result_qag);
 
   this->Rstar = pow(pow(Tstar, 3) * result, -1 / 3.);
+
+  gsl_set_error_handler(old_handler);
 }
 } // namespace BSMPT

--- a/src/models/ClassPotentialR2HDM.cpp
+++ b/src/models/ClassPotentialR2HDM.cpp
@@ -30,7 +30,7 @@ Class_Potential_R2HDM::Class_Potential_R2HDM(const ISMConstants &smConstants)
   NQuarks = 12;
 
   nPar   = 8;
-  nParCT = 11;
+  nParCT = 12;
 
   nVEV = 4;
 

--- a/src/models/ClassPotentialR2HDM.cpp
+++ b/src/models/ClassPotentialR2HDM.cpp
@@ -72,6 +72,7 @@ std::vector<std::string> Class_Potential_R2HDM::addLegendCT() const
   labels.push_back("DT1");
   labels.push_back("DT2");
   labels.push_back("DT3");
+  labels.push_back("DTCharged");
   return labels;
 }
 
@@ -314,6 +315,7 @@ void Class_Potential_R2HDM::set_CT_Pot_Par(const std::vector<double> &p)
   DT1 = p[8];
   DT2 = p[9];
   DT3 = p[10];
+  DTCharged = p[11];
 
   double DIL5CT = 0;
   double DIu3CT = 0;
@@ -558,7 +560,8 @@ void Class_Potential_R2HDM::write() const
 
   ss << "DT1 := " << DT1 << ";\n";
   ss << "DT2 := " << DT2 << ";\n";
-  ss << "DT3:= " << DT3 << ";" << std::endl;
+  ss << "DT3 := " << DT3 << ";\n";
+  ss << "DTCharged:= " << DTCharged << ";" << std::endl;
 
   MatrixXd HiggsRot(NHiggs, NHiggs);
   for (std::size_t i = 0; i < NHiggs; i++)
@@ -699,6 +702,9 @@ std::vector<double> Class_Potential_R2HDM::calc_CT() const
   tmp = -(-v1 * v1 * HesseWeinberg(4, 5) - HesseWeinberg(4, 7) * v1 * v2 +
           NablaWeinberg(7) * v2) /
         v2;
+  // DTCharged
+  parCT.push_back(-NablaWeinberg(2));
+  
   if (std::abs(tmp) < 1e-9) tmp = 0;
   parCT.push_back(tmp);
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the change and the purpose of the PR. -->

- Added a missing CT on the R2HDM. Although we saw that is was zero for all tested points
- Fixed a mistake typo on the Chapman-Jouguet velocity. This has a very small effect. Thanks to Carlo bringing this to our attention.
- Fixed a mistake where relative error and absolute error were switched on a GSL integration. This might have an effect. Thanks Christopher to finding and fixing this.
 
## Type of Change

<!-- Please select only a single option with an "x" or "X". -->

 - [ ] Break (major)
 - [ ] Feature (minor)
 - [x] Bug fix (patch)
 - [ ] No source changes (no version change)
